### PR TITLE
feat(helm-chart): bump helmchart version to 0.3.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
     namespace          = "bitbucket-runner-autoscaler"
     helm_release_name  = "bitbucket-runner-autoscaler"
     helm_chart_name    = "bitbucket-runner-autoscaler"
-    helm_chart_version = "0.2.0"
+    helm_chart_version = "0.3.0"
     helm_repo_url      = "https://lablabs.github.io/bitbucket-runner-autoscaler-helm-chart/"
 
     bitbucket_openid_provider_url = "api.bitbucket.org/2.0/workspaces/${var.bitbucket_workspace_name}/pipelines-config/identity/oidc"


### PR DESCRIPTION
# Description
Bump helm chart version to 0.3.0, which includes support for bitbucket API keys.

## Type of change

- [x] A new feature (PR prefix `feat`)

## How Has This Been Tested?

Runned pipeline in in shared-edge env with API-key which was finished successfully (https://bitbucket.org/labyrinth-labs/hello-world-nodejs/pipelines/results/26/steps/%7B9f73f3e7-eb0c-4a85-9664-49dff803dc4c%7D).

ArgoApps - https://argocd-system.shared-ew1-e.ref-arch.lablabs.io/applications/argo/bitbucket-runner-default?view=tree&node=apps%2FDeployment%2Fbitbucket-runner-autoscaler%2Fbitbucket-runner-default-cleaner%2F0